### PR TITLE
Check for Slack in user-agent before posting to Slack

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -56,5 +56,7 @@ def page_not_found(e):
 
 @app.errorhandler(500)
 def page_not_found(e):
-    send_error_to_slack(e, request.url)
+    user_agent = request.headers.get('user-agent')
+    if re.search(r"Slackbot\-LinkExpanding", user_agent) is None:
+        send_error_to_slack(e, request.url)
     return render_template('500.html'), 500


### PR DESCRIPTION
This should prevent double-posting of error messages to Slack.