### PR TITLE
Add support for https to URL validator

### DIFF
--- a/app/form_validators.py
+++ b/app/form_validators.py
@@ -11,7 +11,7 @@ class MessagingURl(object):
     """
 
     def __call__(self, form, field):
-        messaging_regex = re.compile(r"^http:\/\/emailbuilder.ucsc.edu\/.+")
+        messaging_regex = re.compile(r"^http(|s):\/\/emailbuilder.ucsc.edu\/.+")
         ext = tldextract.extract(field.data)
         if ext.domain != 'ucsc':
             raise ValidationError('URL must belong to a UCSC domain')


### PR DESCRIPTION
WCMS recently switched to HTTPS by default. This change allows email builder URLs to be HTTPS. 